### PR TITLE
exclude build folder in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 node_modules/
+build/
 npm-debug.log
 yarn-error.log
 


### PR DESCRIPTION
Let's ignore the build folder to avoid merge conflict. 